### PR TITLE
240829_BOJ_수 묶기_해결

### DIFF
--- a/jinyoung/240902/BOJ_1744.py
+++ b/jinyoung/240902/BOJ_1744.py
@@ -1,0 +1,47 @@
+import sys
+from collections import deque
+
+sys.stdin = open("input.txt", "r")
+input = sys.stdin.readline
+
+N = int(input())
+
+
+positive_nums = []
+other_nums = []
+
+for _ in range(N):
+    my_nums = int(input())
+    if my_nums > 0 : # 0보다 크면 
+        positive_nums.append(my_nums)
+    else: # 그 외
+        other_nums.append(my_nums)
+
+# 정렬
+positive_nums.sort()
+other_nums.sort(reverse=True)
+
+
+result = 0
+
+while len(positive_nums) > 1 : 
+    num1 = positive_nums.pop()
+    num2 = positive_nums.pop()
+
+    result += max(num1 * num2, num1+num2)
+
+while len(other_nums) > 1:
+    num1 = other_nums.pop()
+    num2 = other_nums.pop()
+    result += max(num1 * num2, num1+num2)
+
+# 남은 숫자들 확인
+if positive_nums :
+    result += positive_nums.pop()
+if other_nums :
+    result += other_nums.pop()
+
+print(result)
+
+
+


### PR DESCRIPTION
`Python3` : `34036KB` / `52ms`

comments...

1. 접근 : 0보다 큰 양수 리스트와 그 외 리스트 분리 후 정렬하였다. (각각 오름차순 / 내림차순 => 곱하여 최댓값을 얻기 위함)
2. 두 수 묶고, 처음 바로 곱해서 더했는데 마지막 테스트케이스 `1 1` 에서 틀렸다. (output `1` / 정답 `2`)
3. 따라서 두 수를 더한 값과 곱한 값을 비교해서 max 값을 result에 더했다. 
4. 해당 리스트의 길이가 홀수 이면 `남은 수를 더하고`  출력할 수 있도록 하였다. 
5. 만약에 테스트 케이스가 없었으면, 반례를 생각하기 어려웠을 지도 ... 🤐